### PR TITLE
Fix: MIPS Architecture Updates and Stabilization

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,85 @@
+# MIPS Single-Cycle Architecture
+
+## Solution Architecture
+
+```mermaid
+graph TD
+    subgraph Computer System
+        CLK[Clock Generator]
+        CPU[MIPS CPU]
+        IMEM[(Instruction Memory)]
+        DMEM[(Data Memory)]
+    end
+
+    CLK -->|clk| CPU
+    CLK -->|clk| DMEM
+    CPU -->|pc| IMEM
+    IMEM -->|instr| CPU
+    CPU -->|dataadr| DMEM
+    CPU -->|writedata| DMEM
+    CPU -->|memwrite| DMEM
+    DMEM -->|readdata| CPU
+```
+
+## CPU Internal Architecture
+
+```mermaid
+graph TD
+    subgraph CPU
+        CTRL[Controller]
+        DP[Datapath]
+    end
+    
+    subgraph Controller
+        MD[Main Decoder]
+        AD[ALU Decoder]
+    end
+    
+    subgraph Datapath
+        PC[PC Register]
+        RF[Register File]
+        ALU[Arithmetic Logic Unit]
+        EXT[Sign Extend]
+    end
+
+    CTRL -->|memtoreg, memwrite, alusrc, regdst, regwrite, jump, pcsrc| DP
+    CTRL -->|alucontrol 4-bit| ALU
+    DP -->|zero| CTRL
+```
+
+## Instruction Execution Sequence
+
+```mermaid
+sequenceDiagram
+    participant PC as Program Counter
+    participant IMEM as Instruction Mem
+    participant CTRL as Controller
+    participant RF as Register File
+    participant ALU as ALU
+    participant DMEM as Data Mem
+
+    PC->>IMEM: Fetch Instruction (PC)
+    IMEM-->>CTRL: Instruction [31:26], [5:0]
+    IMEM-->>RF: Read Registers [25:21], [20:16]
+    IMEM-->>ALU: Sign-Extended Imm [15:0] (if alusrc)
+    
+    CTRL->>RF: Control Signals (regdst, regwrite)
+    CTRL->>ALU: ALU Control (4-bit)
+    
+    RF-->>ALU: Operand A & Operand B
+    ALU-->>DMEM: ALU Result (Address)
+    RF-->>DMEM: Write Data
+    
+    CTRL->>DMEM: memwrite
+    DMEM-->>RF: Read Data (if memtoreg)
+    ALU-->>RF: ALU Result (if not memtoreg)
+```
+
+## Unimplemented Designs (Future Work)
+The current single-cycle MIPS implementation is functional but currently lacks the following common CPU architecture features:
+- **Pipelining**: Breaking down the cycle into IF, ID, EX, MEM, WB stages using pipeline registers.
+- **Hazard Detection & Forwarding Unit**: Required to resolve data and control hazards if pipelining is introduced.
+- **Exception Handling (Coprocessor 0)**: Support for handling internal exceptions (overflows, undefined instructions) and external interrupts.
+- **Floating-Point Unit (Coprocessor 1)**: For hardware acceleration of IEEE 754 operations.
+- **Cache Memory**: Replacing direct combinatorial memory access with hierarchical L1/L2 caches.
+- **Branch Prediction**: Static or dynamic branch predictors to minimize control hazard penalties.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.0.1] - 2026-04-23
+### Added
+- `GEMINI.md` to document project guidelines, structure, and architecture.
+- `ARCHITECTURE.md` to map out UML and Mermaid sequence/structural diagrams.
+- Missing instruction decodings for `div` and `nor` in `aludec.sv`.
+
+### Changed
+- Expanded `alucontrol` signal from 3-bit to 4-bit across `cpu`, `controller`, `datapath`, `alu`, and `aludec` modules to fix operational collision.
+- Refactored `clock.sv` generator to a clean `always` block for simulator stability.
+
+### Fixed
+- Prevented R-type `mult` and `div` instructions from asserting `regwrite` in the `controller`.
+- Protected Register 0 (`$0`) from being written to in `regfile.sv`.
+- Fixed array out of bounds read (`RAM[84]`) in `tb_computer.sv`, correcting it to word-aligned index `21`.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,68 @@
+# MIPS CPU HDL Catalog
+
+This repository is used in the **ECE 251 Computer Architecture** course at **Cooper Union** (cooper.edu). It serves as a catalog of SystemVerilog components to build a computer, specifically implementing a single-cycle MIPS-based 32-bit RISC processor. The project was developed by **Prof Rob Marano** and is based on the architecture described in *Digital Design & Computer Architecture* by Harris and Harris.
+
+## Project Overview
+
+The project implements a single-cycle MIPS CPU using a modular approach. Each hardware component (ALU, Adder, Register File, etc.) is defined in its own directory within the `behavorial/` folder.
+
+### Key Components
+- **CPU**: Top-level CPU module (`behavorial/cpu/cpu.sv`) integrating the controller and datapath.
+- **Controller**: Decodes instructions and generates control signals (`behavorial/controller/controller.sv`).
+- **Datapath**: Connects registers and the ALU to execute instructions (`behavorial/datapath/datapath.sv`).
+- **ALU**: Arithmetic Logic Unit supporting ADD, SUB, AND, OR, SLT, and MULT (`behavorial/alu/alu.sv`).
+- **Memory**: Instruction Memory (`imem`) and Data Memory (`dmem`). `imem` loads programs from hex files.
+
+## Getting Started
+
+### Prerequisites
+- **Icarus Verilog** (`iverilog`): For compilation and simulation.
+- **VVP**: The runtime for Icarus Verilog.
+- **GTKWave**: For viewing simulation waveforms (`.vcd` files).
+- **Make**: To automate the build process.
+
+### Building and Running
+Each module directory contains a `Makefile`. The main entry point for simulating the full computer is in `behavorial/computer/`.
+
+```bash
+cd behavorial/computer/
+
+# Compile the design and testbench
+make compile
+
+# Run the simulation (generates tb_computer.vcd)
+make simulate
+
+# View waveforms (requires a GUI environment)
+make display
+
+# Cleanup generated files
+make clean
+```
+
+### Loading Programs
+Programs are stored as hex strings in files like `program_exe` or `mult-prog_exe` in the `behavorial/imem/` or `behavorial/computer/` directories.
+To switch between programs, you must edit `behavorial/imem/imem.sv` and update the `$readmemh` call:
+
+```verilog
+initial begin
+  // Update this path to load a different program
+  $readmemh("mult-prog_exe", RAM);
+end
+```
+
+## Development Conventions
+
+- **Modularity**: Components are isolated in subdirectories.
+- **Includes**: Files use `\`include` to reference dependencies. Pathing is relative (e.g., `../alu/alu.sv`).
+- **Include Guards**: Every file is wrapped in `\`ifndef MODULE_NAME` / `\`define MODULE_NAME` to prevent multiple inclusions.
+- **Headers**: All files include a standard Cooper Union ECE 251 header with attribution and metadata.
+- **Testbenches**: Named with the `tb_` prefix (e.g., `tb_computer.sv`).
+- **Parameterization**: Modules often use parameters (e.g., `#(parameter n = 32)`) for bit-width flexibility.
+
+## Directory Structure Highlights
+- `behavorial/computer/`: Top-level "system-on-chip" assembly.
+- `behavorial/cpu/`: Core CPU logic.
+- `behavorial/alu/`: Math and logic operations.
+- `behavorial/regfile/`: 32-port register file.
+- `behavorial/imem/` & `behavorial/dmem/`: Memory modules.

--- a/PR_SUMMARY.md
+++ b/PR_SUMMARY.md
@@ -1,0 +1,14 @@
+# Pull Request Summary: Architecture Fixes & Stabilization
+
+## Previous Work (from last PR & Commits)
+- Merged core modules (`aludec`, `cpu`, `datapath`, `regfile`).
+- Added `dmem` module.
+- Fixed `tb_computer.sv` and added `program_exe` ensuring the single-cycle computer works fundamentally.
+
+## Current Design Changes & Fixes
+- **Register File Security**: Protected Register 0 (`$0`) from being overwritten by modifying `regfile.sv` to explicitly check `wa3 != 0`.
+- **ALU Control Bus Expansion**: Expanded `alucontrol` from 3-bit to 4-bit across `alu`, `aludec`, `datapath`, `cpu`, and `controller` to provide enough addressing space for all implemented instructions, removing the collision between MULT/DIV and NOR/MFHI.
+- **ALU Decoder Extensions**: Mapped `nor` and `div` instructions into `aludec.sv`.
+- **Controller Register Write Fix**: Disabled the `regwrite` signal in `controller.sv` for `mult` and `div` R-type instructions to correctly prevent writing their combinational outputs to the main register file.
+- **Testbench Stabilization**: Corrected an out-of-bounds array access in `tb_computer.sv` (from byte address 84 to word address 21).
+- **Clock Generator Fix**: Replaced problematic while-loops in `clock.sv` with a robust simulation-friendly continuous toggle block.

--- a/behavorial/alu/alu.sv
+++ b/behavorial/alu/alu.sv
@@ -22,7 +22,7 @@ module alu
     //
     input  logic        clk,
     input  logic [(n-1):0] a, b,
-    input  logic [2:0]  alucontrol,
+    input  logic [3:0]  alucontrol,
     output logic [(n-1):0] result,
     output logic        zero
 );
@@ -44,41 +44,40 @@ module alu
 
     always @(a,b,alucontrol) begin
         case (alucontrol)
-            3'b000: result = a & b;             // and
-            3'b001: result = a | b;             // or
-            3'b010: result = a + b;             // add
-            3'b011: result = ~(a | b);           // nor
-            3'b100: result = HiLo[(n-1):0];     // MFLO
-            3'b101: result = HiLo[(2*n-1):n];   // MFHI
-            3'b110: result = sumSlt;            // sub
-            // 3'b111: result = sumSlt[(n-1)];     // slt
-            3'b111: begin                       // slt
-				if (a[31] != b[31])
-					if (a[31] > b[31])
-						result = 1;
-					else
-						result = 0;
-				else
-					if (a < b)
-						result = 1;
-					else
-						result = 0;
+            4'b0000: result = a & b;             // and
+            4'b0001: result = a | b;             // or
+            4'b0010: result = a + b;             // add
+            4'b0011: result = ~(a | b);          // nor
+            4'b0100: result = HiLo[(n-1):0];     // MFLO
+            4'b0101: result = HiLo[(2*n-1):n];   // MFHI
+            4'b0110: result = sumSlt;            // sub
+            4'b0111: begin                       // slt
+                                if (a[31] != b[31])
+                                        if (a[31] > b[31])
+                                                result = 1;
+                                        else
+                                                result = 0;
+                                else
+                                        if (a < b)
+                                                result = 1;
+                                        else
+                                                result = 0;
             end
+            default: result = {n{1'bx}};         // default for mult/div combinational output
         endcase
     end
 
     //Multiply and divide results are only stored at clock falling edge.
     always @(negedge clk) begin
         case (alucontrol)
-            3'b011: HiLo = a * b; // mult
-            3'b101: // div
+            4'b1000: HiLo = a * b; // mult
+            4'b1001: // div
             begin
                 HiLo[(n-1):0] = a / b;
                 HiLo[(2*n-1):n] = a % b;
             end
-        endcase				
+        endcase
     end
-
 endmodule
 
 `endif // ALU

--- a/behavorial/aludec/aludec.sv
+++ b/behavorial/aludec/aludec.sv
@@ -22,27 +22,29 @@ module aludec
     //
     input  logic [5:0] funct,
     input  logic [1:0] aluop,
-    output logic [2:0] alucontrol);
+    output logic [3:0] alucontrol);
     //
     // ---------------- MODULE DESIGN IMPLEMENTATION ----------------
     //
     always @*
     begin
         case(aluop)
-        2'b00: alucontrol <= 3'b010;  // add (for lw/sw/addi)
-        2'b01: alucontrol <= 3'b110;  // sub (for beq)
+        2'b00: alucontrol <= 4'b0010;  // add (for lw/sw/addi)
+        2'b01: alucontrol <= 4'b0110;  // sub (for beq)
         default:
             // for R-type instructions
             case(funct)
-                6'b100000: alucontrol <= 3'b010; // add
-                6'b100010: alucontrol <= 3'b110; // sub
-                6'b100100: alucontrol <= 3'b000; // and
-                6'b100101: alucontrol <= 3'b001; // or
-                6'b101010: alucontrol <= 3'b111; // slt
-                6'b011000: alucontrol <= 3'b011; // mult
-                6'b010010: alucontrol <= 3'b100; // mflo
-                6'b010000: alucontrol <= 3'b101; // mfhi
-                default:   alucontrol <= 3'bxxx; // ???
+                6'b100000: alucontrol <= 4'b0010; // add
+                6'b100010: alucontrol <= 4'b0110; // sub
+                6'b100100: alucontrol <= 4'b0000; // and
+                6'b100101: alucontrol <= 4'b0001; // or
+                6'b100111: alucontrol <= 4'b0011; // nor
+                6'b101010: alucontrol <= 4'b0111; // slt
+                6'b011000: alucontrol <= 4'b1000; // mult
+                6'b011010: alucontrol <= 4'b1001; // div
+                6'b010010: alucontrol <= 4'b0100; // mflo
+                6'b010000: alucontrol <= 4'b0101; // mfhi
+                default:   alucontrol <= 4'bxxxx; // ???
             endcase
         endcase
     end

--- a/behavorial/clock/clock.sv
+++ b/behavorial/clock/clock.sv
@@ -36,22 +36,12 @@ module clock
       start_clock <= 0;
     end
 
-    always @(posedge ENABLE or negedge ENABLE) begin
-        if (ENABLE) begin
-            start_clock = 1;
-        end
-        else begin
-            start_clock = 0;
-        end
-        // #ticks CLOCK = ~CLOCK;
-    end
-    always @(start_clock) begin
-        CLOCK = 0;
-        while (start_clock) begin
-            #(clock_off) CLOCK = 1;
-            #(clock_on) CLOCK = 0;
-        end
-        CLOCK = 0;
+    always begin
+        #(ticks/2);
+        if (ENABLE)
+            CLOCK = ~CLOCK;
+        else
+            CLOCK = 0;
     end
 endmodule
 

--- a/behavorial/computer/tb_computer.sv
+++ b/behavorial/computer/tb_computer.sv
@@ -120,13 +120,13 @@ module tb_computer;
   always @(negedge clk, posedge clk) begin
     // check results
     // TODO: You need to update the checks below
-    // if (dut.dmem.RAM[84] === 32'h9504)
+    // if (dut.dmem.RAM[21] === 32'h9504)
     //   begin
     //     $display("Successfully wrote 0x%4h at RAM[%3d]",84,32'h9504);
     //     firstTest = 1'b1;
     //   end
 
-    if (dut.dmem.RAM[84] === 32'h96)
+    if (dut.dmem.RAM[21] === 32'h96)
       begin
         $display("Successfully wrote 0x%4h at RAM[%3d]",84,32'h0096);
         firstTest = 1'b1;

--- a/behavorial/controller/controller.sv
+++ b/behavorial/controller/controller.sv
@@ -29,16 +29,21 @@ module controller
     output logic       pcsrc, alusrc,
     output logic       regdst, regwrite,
     output logic       jump,
-    output logic [2:0] alucontrol
+    output logic [3:0] alucontrol
 );
     //
     // ---------------- MODULE DESIGN IMPLEMENTATION ----------------
     //
     logic [1:0] aluop;
     logic       branch;
+    logic       regwrite_md;
     
     // CPU main decoder
-    maindec md(op, memtoreg, memwrite, branch, alusrc, regdst, regwrite, jump, aluop);
+    maindec md(op, memtoreg, memwrite, branch, alusrc, regdst, regwrite_md, jump, aluop);
+    
+    // Prevent regwrite for mult (0x18) and div (0x1a) instructions (they write to HiLo instead)
+    assign regwrite = regwrite_md & ~(op == 6'b000000 && (funct == 6'b011000 || funct == 6'b011010));
+
     // CPU's ALU decoder
     aludec  ad(funct, aluop, alucontrol);
 

--- a/behavorial/cpu/cpu.sv
+++ b/behavorial/cpu/cpu.sv
@@ -36,7 +36,7 @@ module cpu
 
     // cpu internal components
     logic       memtoreg, alusrc, regdst, regwrite, jump, pcsrc, zero;
-    logic [2:0] alucontrol;
+    logic [3:0] alucontrol;
     
     controller c(instr[(31):26], instr[5:0], zero,
                     memtoreg, memwrite, pcsrc,

--- a/behavorial/datapath/datapath.sv
+++ b/behavorial/datapath/datapath.sv
@@ -32,7 +32,7 @@ module datapath
     input  logic        memtoreg, pcsrc,
     input  logic        alusrc, regdst,
     input  logic        regwrite, jump,
-    input  logic [2:0]  alucontrol,
+    input  logic [3:0]  alucontrol,
     output logic        zero,
     output logic [(n-1):0] pc,
     input  logic [(n-1):0] instr,

--- a/behavorial/regfile/regfile.sv
+++ b/behavorial/regfile/regfile.sv
@@ -40,7 +40,7 @@ module regfile
     // on falling edge of clk
 
     always @(posedge clk)
-        if (we3) rf[wa3] <= wd3;	
+        if (we3 && wa3 != 0) rf[wa3] <= wd3;	
 
     assign rd1 = (ra1 != 0) ? rf[ra1] : 0;
     assign rd2 = (ra2 != 0) ? rf[ra2] : 0;


### PR DESCRIPTION
# Pull Request Summary: Architecture Fixes & Stabilization

## Previous Work (from last PR & Commits)
- Merged core modules (`aludec`, `cpu`, `datapath`, `regfile`).
- Added `dmem` module.
- Fixed `tb_computer.sv` and added `program_exe` ensuring the single-cycle computer works fundamentally.

## Current Design Changes & Fixes
- **Register File Security**: Protected Register 0 (`$0`) from being overwritten by modifying `regfile.sv` to explicitly check `wa3 != 0`.
- **ALU Control Bus Expansion**: Expanded `alucontrol` from 3-bit to 4-bit across `alu`, `aludec`, `datapath`, `cpu`, and `controller` to provide enough addressing space for all implemented instructions, removing the collision between MULT/DIV and NOR/MFHI.
- **ALU Decoder Extensions**: Mapped `nor` and `div` instructions into `aludec.sv`.
- **Controller Register Write Fix**: Disabled the `regwrite` signal in `controller.sv` for `mult` and `div` R-type instructions to correctly prevent writing their combinational outputs to the main register file.
- **Testbench Stabilization**: Corrected an out-of-bounds array access in `tb_computer.sv` (from byte address 84 to word address 21).
- **Clock Generator Fix**: Replaced problematic while-loops in `clock.sv` with a robust simulation-friendly continuous toggle block.
