### PR TITLE
docs: finalize PR summary and add Cache Telemetry UML diagrams

### DIFF
--- a/pipelined_cached_computer/ARCHITECTURE.md
+++ b/pipelined_cached_computer/ARCHITECTURE.md
@@ -113,3 +113,37 @@ To resolve decoding collisions, the 3-bit `alucontrol` was natively expanded to 
 | SLT | `0111` | Combinational | Set if a < b |
 | DIV | `1001` | Sequential | a / b & a % b (updates HiLo) |
 | MULT | `1000` | Sequential | a * b (updates HiLo) |
+
+## Cache Controller Telemetry & Performance Integration
+
+The `pipelined_cached_computer` extends the standard datapath by injecting a highly associative Cache Controller between the CPU and the Main Memory (`dmem.sv`).
+
+The testbench (`tb_computer.sv`) interfaces directly with the Cache Controller state machine to dynamically calculate Hit/Miss ratios and an Effective Cycles Per Instruction (CPI).
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant TB as Testbench (Performance Counters)
+    participant DP as Pipelined Datapath (MEM Stage)
+    participant Cache as Cache Controller
+    participant RAM as Main Memory (10 Cycle Latency)
+
+    DP->>Cache: Request Memory Access (Read/Write)
+    Cache->>Cache: Check Tag & Valid Bits (Cycle 1)
+    
+    alt Cache Hit
+        Cache-->>DP: Return Data Immediately
+        Cache-->>TB: Assert Hit Signal
+        TB->>TB: Increment cache_hits
+    else Cache Miss
+        Cache-->>TB: Assert Miss Signal
+        TB->>TB: Increment cache_misses
+        Cache->>RAM: Stall Pipeline (mem_stall = 1)
+        Note over RAM: Wait 10 Clock Cycles...
+        RAM-->>Cache: Block Load Complete
+        Cache-->>DP: Resume Pipeline (mem_stall = 0)
+    end
+    
+    TB->>TB: Track instr_count (on successful Decode)
+    TB->>TB: Calculate Effective CPI (cycles / instr)
+```

--- a/pipelined_cached_computer/PR_SUMMARY.md
+++ b/pipelined_cached_computer/PR_SUMMARY.md
@@ -23,7 +23,14 @@ This PR addresses critical architectural bugs identified in the 5-stage MIPS32 p
 - Successfully ran the standard baseline simulation (`test_prog.asm`) verifying `RAW` hazard forwarding and pipelined branch flushes.
 - Successfully ran the asynchronous interrupt simulation (`test_exceptions.asm` via `tb_exceptions.sv`). The testbench correctly triggered an exception, redirected the datapath to the kernel handler, successfully tracked state into `$k0`, and correctly captured `EPC = 0x0000000c`.
 
+## Centralized Tooling & Metric Patches (Catalog Integration)
+- **Assembler Patch (`tools/assembler.py`)**: Modified to support `MULT`, `MFLO`, and `MFHI` R-type encodings. Added silent ignoring for `.end` pseudo-directives and sanitized Unicode em-dashes to allow compilation of legacy textbook programs.
+- **Metric Restoration (`tb_computer.sv`)**: Fixed the `instr_count` telemetry. The counter now cleanly targets `dut.mips_pipelined.dp.instrD` rather than the dynamic `instrF` bus, ensuring the Effective CPI calculation is perfectly accurate and ignores pipeline bubbles.
+- **Exhaustive Verification**: A batch test was executed against all 13 legacy and active programs inside the `programs/` directory. All 13 successfully reached the Memory-Mapped I/O Halt (`sw $zero, 252($zero)`) and output perfect cycle, instruction, and cache hit/miss telemetry.
+
 ## Documentation Updates
 - Updated `GEMINI.md` and `TODO.md` to reflect all architectural tasks as `[RESOLVED]`.
 - Updated `README.md` to mirror the accurate 4-bit ALU control specifications and documented modern VCD wave inspection tools.
-- Generated `ARCHITECTURE.md` to outline the software architecture diagrams and exception sequence logic using Mermaid.js.
+- Generated `ARCHITECTURE.md` to outline the software architecture diagrams, the `Exception Sequence Logic`, and the `Cache Performance Telemetry` interactions using Mermaid.js.
+- Generated `CHALLENGE_TODO.md` outlining the hardware requirements for FPU/SRL execution.
+- Generated `VERIFICATION.md` logging the formal execution metrics of the 13-program batch suite.


### PR DESCRIPTION
This commit finalizes the integration documentation. PR_SUMMARY.md has been updated to fully reflect the 13-program verification batch and the centralized tooling patches. ARCHITECTURE.md now features a Mermaid sequence diagram detailing the Cache Controller interactions with the datapath and the testbench telemetry.
